### PR TITLE
I-6 Fixed snapping text

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -271,10 +271,11 @@ section {
     background: rgba(0, 0, 0, 0.35);
     border: 1px solid rgba(255, 255, 255, 0.08);
     margin-bottom: 12px;
-    min-height: 44px;
+    height: 92px;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 6px;
+    overflow: hidden;
 }
 
 .cursor {
@@ -284,9 +285,17 @@ section {
 }
 
 @keyframes cursorBlink {
-    0% { opacity: 1; }
-    50% { opacity: 0; }
-    100% { opacity: 1; }
+    0% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0;
+    }
+
+    100% {
+        opacity: 1;
+    }
 }
 
 .seed-signal-note {


### PR DESCRIPTION
This pull request makes adjustments to the `static/css/styles.css` file, focusing on improving the layout and visual consistency of `section` elements, as well as reformatting the `cursorBlink` keyframes for better readability.

**Layout and styling updates:**

* The `section` elements now have a fixed height of `92px` (previously a minimum height of `44px`), align items to the top (`flex-start`), and hide overflow content for a more consistent appearance.

**Code formatting improvements:**

* The `@keyframes cursorBlink` animation has been reformatted for improved readability, with each keyframe block expanded and properly indented. No functional changes were made.